### PR TITLE
feature: support auto-cloning of source control backed services

### DIFF
--- a/dc.sh
+++ b/dc.sh
@@ -22,8 +22,7 @@ dc_get_links() {
 }
 
 dc_get_services_with_source() {
-	# pluck out service names only
-	dc_get_sources | sed -e 's/^\(.*\)=.*$/\1/'
+	dc_get_sources | sed -e 's/^\[\(.*\)\]=.*$/\1/'
 }
 
 # TODO: remove this once references are updated to dc_get_service_and_dependencies_with_source
@@ -106,5 +105,5 @@ generate_compose_file_caches() {
 parse_sources() {
 	parse_yaml $(dc_file) |
 		grep '^services_.*_labels_com.tarantino.source=' |
-		sed -e 's/^services_\(.*\)_labels_com.tarantino.source=/\1=/'
+		sed -e 's/^services_\(.*\)_labels_com.tarantino.source=(\(.*\))$/[\1]=\2/'
 }

--- a/dc.sh
+++ b/dc.sh
@@ -25,11 +25,6 @@ dc_get_services_with_source() {
 	dc_get_sources | sed -e 's/^\[\(.*\)\]=.*$/\1/'
 }
 
-# TODO: remove this once references are updated to dc_get_service_and_dependencies_with_source
-dc_get_repos() {
-	dc_get_service_and_dependencies_with_source $@
-}
-
 dc_get_service_and_dependencies_with_source() {
 	# intersect service & dependencies with source backed services
 	sort <(dc_get_service_and_dependencies $@) <(dc_get_services_with_source) | uniq -d

--- a/dc.sh
+++ b/dc.sh
@@ -21,43 +21,53 @@ dc_get_links() {
 	done
 }
 
+# TODO: remove this once references are updated to dc_get_services
 dc_get_all_services() {
-	if [ "$TT_IS_GLOBAL" = true ]; then
-		generate_service_lists
-		cat "$(get_workspace_cache_dir)/services"
-	else
-		dc config --services
-	fi
+	get_services
 }
 
+# TODO: remove this once references are updated to dc_get_services_with_source
 dc_get_services() {
-	dc_get_all_services | grep -Ev $NOT_SERVICES_PATTERN
+	dc_get_services_with_source
 }
 
+dc_get_services_with_source() {
+	# pluck out service names only
+	dc_get_sources | sed -e 's/^\(.*\)=.*$/\1/'
+}
+
+# TODO: remove this once references are updated to dc_get_service_and_dependencies_with_source
 dc_get_repos() {
+	dc_get_service_and_dependencies_with_source $@
+}
+
+dc_get_service_and_dependencies_with_source() {
+	# intersect service & dependencies with source backed services
+	sort <(dc_get_service_and_dependencies $@) <(dc_get_services_with_source) | uniq -d
+}
+
+dc_get_service_and_dependencies() {
 	if [[ $# -gt 0 ]]; then
 		services=
-		repos=$@
-		while [ "$services" != "$repos" ]; do
-			services=$repos
-			repos=
+		result=$@ # start with the ones passed in
+		while [ "$services" != "$result" ]; do
+			services=$result
+			result=
+
+			# for each service...
 			for service in $services; do
-				self=$(echo $service | grep -Ev $NOT_SERVICES_PATTERN)
-				if [ ! -z "$self" ]; then
-					repos="$repos $self"
-				fi
-				links=$(dc_get_links $service | grep -Ev $NOT_SERVICES_PATTERN)
-				if [ ! -z "$links" ]; then
-					repos="$repos $links"
-				fi
+				# add service and linked services to result
+				result="$result $service $(dc_get_links $service)"
 			done
-			repos=$(echo $repos | awk -v RS="[\n ]" '!a[$0]++')
+
+			# remove duplicates and normalize whitespace
+			result=$(echo $result | awk -v RS="[\n ]" '!a[$0]++')
 		done
-		if [ ! -z "$repos" ]; then
-			echo "$repos"
+		if [ ! -z "$result" ]; then
+			echo "$result"
 		fi
 	else
-		echo "$(tt_get_services)"
+		echo "$(get_services)"
 	fi
 }
 
@@ -67,7 +77,26 @@ get_workspace_cache_dir() {
 	echo $cachedir
 }
 
-generate_service_lists() {
+# TODO: rename this to dc_get_services
+get_services() {
+	if [ "$TT_IS_GLOBAL" = true ]; then
+		generate_compose_file_caches
+		cat "$(get_workspace_cache_dir)/services"
+	else
+		dc config --services
+	fi
+}
+
+dc_get_sources() {
+	if [ "$TT_IS_GLOBAL" = true ]; then
+		generate_compose_file_caches
+		cat "$(get_workspace_cache_dir)/sources"
+	else
+		parse_sources
+	fi
+}
+
+generate_compose_file_caches() {
 	local md5check=$(get_workspace_cache_dir)/dc_file.md5
 
 	if [ -f "$md5check" ]; then
@@ -79,5 +108,14 @@ generate_service_lists() {
 	local services_cache_file=$(get_workspace_cache_dir)/services
 	dc config --services > "$services_cache_file"
 
+	local sources_cache_file=$(get_workspace_cache_dir)/sources
+	parse_sources > $sources_cache_file
+
 	md5sum "$(dc_file)" > "$md5check"
+}
+
+parse_sources() {
+	parse_yaml $(dc_file) |
+		grep '^services_.*_labels_com.tarantino.source=' |
+		sed -e 's/^services_\(.*\)_labels_com.tarantino.source=/\1=/'
 }

--- a/dc.sh
+++ b/dc.sh
@@ -26,11 +26,6 @@ dc_get_all_services() {
 	get_services
 }
 
-# TODO: remove this once references are updated to dc_get_services_with_source
-dc_get_services() {
-	dc_get_services_with_source
-}
-
 dc_get_services_with_source() {
 	# pluck out service names only
 	dc_get_sources | sed -e 's/^\(.*\)=.*$/\1/'

--- a/dc.sh
+++ b/dc.sh
@@ -22,7 +22,7 @@ dc_get_links() {
 }
 
 dc_get_all_services() {
-	if [ "$TT_IS_GLOBAL" = true -a -f "$ALL_SERVICES_FILE" ]; then
+	if [ "$TT_IS_GLOBAL" = true ]; then
 		generate_service_lists
 		cat "$(get_workspace_cache_dir)/services"
 	else

--- a/dc.sh
+++ b/dc.sh
@@ -21,11 +21,6 @@ dc_get_links() {
 	done
 }
 
-# TODO: remove this once references are updated to dc_get_services
-dc_get_all_services() {
-	get_services
-}
-
 dc_get_services_with_source() {
 	# pluck out service names only
 	dc_get_sources | sed -e 's/^\(.*\)=.*$/\1/'
@@ -62,7 +57,7 @@ dc_get_service_and_dependencies() {
 			echo "$result"
 		fi
 	else
-		echo "$(get_services)"
+		echo "$(dc_get_services)"
 	fi
 }
 
@@ -72,8 +67,7 @@ get_workspace_cache_dir() {
 	echo $cachedir
 }
 
-# TODO: rename this to dc_get_services
-get_services() {
+dc_get_services() {
 	if [ "$TT_IS_GLOBAL" = true ]; then
 		generate_compose_file_caches
 		cat "$(get_workspace_cache_dir)/services"

--- a/parse-yaml.sh
+++ b/parse-yaml.sh
@@ -6,7 +6,7 @@ parse_yaml() {
 	local w
 	local fs
 	s='[[:space:]]*'
-	w='[a-zA-Z0-9_]*'
+	w='[a-zA-Z0-9_.]*'
 	fs="$(echo @|tr @ '\034')"
 	sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
 		-e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" $1 |

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     volumes:
       - ${TT_PROJECTS}/jackie:/app:ro
     working_dir: /app
+    labels:
+      com.tarantino.source: git@github.com:meet-tarantino/jackie.git
 
   jules:
     image: mhart/alpine-node
@@ -28,6 +30,9 @@ services:
       jules_jackie: http://jackie:8080
     links:
       - mongo
+      - jackie
     volumes:
       - ${TT_PROJECTS}/jules:/app:ro
     working_dir: /app
+    labels:
+      com.tarantino.source: git@github.com:meet-tarantino/jules.git

--- a/tt
+++ b/tt
@@ -134,12 +134,12 @@ tt_browse() {
 
 tt_check() {
 	local projects=$TT_PROJECTS
-	local repos=$(dc_get_repos $*)
+	local service=$(dc_get_service_and_dependencies_with_source $@)
 	local success=true
 
-	for repo in $repos; do
-		if [ ! -d "$projects/$repo" ]; then
-			echo $repo not found in projects directory $projects.
+	for service in $service; do
+		if [ ! -d "$projects/$service" ]; then
+			echo $service not found in projects directory $projects.
 			success=false
 		fi
 	done
@@ -181,7 +181,7 @@ tt_clone() {
 
 tt_pull() {
 	local projects=$TT_PROJECTS
-	local repos=$(dc_get_repos $*)
+	local services=$(dc_get_service_and_dependencies_with_source $@)
 
 	local skipped=
 	local updated=
@@ -189,21 +189,21 @@ tt_pull() {
 	local current=
 
 	pushd .
-	for repo in $repos; do
-		if [ -d "$projects/$repo" ]; then
-			cd $projects/$repo
-			echo ---- $repo ----
+	for service in $services; do
+		if [ -d "$projects/$service" ]; then
+			cd $projects/$service
+			echo ---- $service ----
 			if [ "$(git status --porcelain | wc -c)" = "0" ]; then
 				current=$(git rev-parse HEAD)
 				git pull --rebase --ff-only
 				if [ $? -ne 0 ]; then
-					skipped="$skipped $repo"
+					skipped="$skipped $service"
 				elif [ $current != "$(git rev-parse HEAD)" ]; then
-					updated="$updated $repo"
+					updated="$updated $service"
 				fi
 			else
-				echo Skipping $repo because the working directory is not clean.
-				skipped="$skipped $repo"
+				echo Skipping $service because the working directory is not clean.
+				skipped="$skipped $service"
 			fi
 		fi
 	done

--- a/tt
+++ b/tt
@@ -2,7 +2,7 @@
 
 # variables
 TT_PROJECTS=${TT_PROJECTS:-~/projects}
-TT_GIT_BASE=${TT_GIT_BASE:-git@gitub.com:meet-tarantino}
+TT_GIT_BASE=${TT_GIT_BASE:-git@github.com:meet-tarantino}
 
 TT_IS_GLOBAL=$([ "$0" = "/usr/local/bin/tt" ] && echo true || echo false)
 TT_SHARE=$([ $TT_IS_GLOBAL = true ] && echo /usr/local/share/tarantino || dirname $0)

--- a/tt
+++ b/tt
@@ -19,8 +19,8 @@ tt_get_all_services() {
 	dc_get_all_services
 }
 
-tt_get_services() {
-	dc_get_services
+tt_get_services_with_source() {
+	dc_get_services_with_source
 }
 
 info() {

--- a/tt
+++ b/tt
@@ -15,8 +15,8 @@ source $TT_SHARE/install.sh
 source $TT_SHARE/parse-yaml.sh
 source $TT_SHARE/workspace.sh
 
-tt_get_all_services() {
-	dc_get_all_services
+tt_get_services() {
+	dc_get_services
 }
 
 tt_get_services_with_source() {

--- a/tt
+++ b/tt
@@ -2,7 +2,6 @@
 
 # variables
 TT_PROJECTS=${TT_PROJECTS:-~/projects}
-TT_GIT_BASE=${TT_GIT_BASE:-git@github.com:meet-tarantino}
 
 TT_IS_GLOBAL=$([ "$0" = "/usr/local/bin/tt" ] && echo true || echo false)
 TT_SHARE=$([ $TT_IS_GLOBAL = true ] && echo /usr/local/share/tarantino || dirname $0)

--- a/tt
+++ b/tt
@@ -154,23 +154,28 @@ tt_check() {
 
 tt_clone() {
 	local projects=$TT_PROJECTS
-	local repos=$(dc_get_repos $*)
-	local success=true
+	local services=$(dc_get_service_and_dependencies $@)
+	eval "declare -A TT_SOURCES=($(dc_get_sources))" # sources hashtable
 
 	pushd . &> /dev/null
-	for repo in $repos; do
-		if [ ! -d "$projects/$repo" ]; then
-			echo $repo not found in projects directory $projects, cloning it.
-			git clone $TT_GIT_BASE/$repo.git $projects/$repo || return 1;
+
+	for service in $services; do
+		local src=${TT_SOURCES[$service]}
+
+		# if source is defined but directory doesn't exist
+		if [ ! -z "$src" -a ! -d "$projects/$service" ]; then
+			echo $service not found in projects directory $projects, cloning it.
+			git clone $src $projects/$service || return 1;
 
 			# run npm install for any npm packages (the service, or its components)
-			find "$projects/$repo" -name 'package.json' -not -path "**/bower_components/*" | xargs --no-run-if-empty dirname | grep -v 'node_modules' | while read module; do
+			find "$projects/$service" -name 'package.json' -not -path "**/bower_components/*" | xargs --no-run-if-empty dirname | grep -v 'node_modules' | while read module; do
 				cd $module
 				echo in $module directory running: npm install
 				npm install
 			done
 		fi
 	done
+
 	popd &> /dev/null
 }
 

--- a/tt_completion
+++ b/tt_completion
@@ -62,7 +62,7 @@ completion_all_services() {
 }
 
 completion_services() {
-	tarantino get_services 2> /dev/null
+	tarantino get_services_with_source 2> /dev/null
 }
 
 completion_running_services() {

--- a/tt_completion
+++ b/tt_completion
@@ -58,7 +58,7 @@ completion_base() {
 }
 
 completion_all_services() {
-	tarantino get_all_services 2> /dev/null
+	tarantino get_services 2> /dev/null
 }
 
 completion_services() {


### PR DESCRIPTION
Closes #7.

## to-do

- [ ] - ~update documentation for how to specify source~
- [x] - remove TT_GIT_BASE and rely on the `com.tarantino.source` label for the full repo path
- [x] - update the template `docker-compose.yml` to demonstrate using jules/jackie

--------------------

This proposal would enable users to add a label to a docker-compose service. Take a look at the bottom of this example:

```
  tix:
    build: ./
    ports:
      - "8082:8081"
    environment:
      tix_graphite__host: 'graphite'
      tix_stats__host: 'graphite'
    volumes:
      - ./sql:/app/sql:ro

  deletemetix:
    build: ./
    ports:
      - "8082:8081"
    environment:
      tix_graphite__host: 'graphite'
      tix_stats__host: 'graphite'
    volumes:
      - ./sql:/app/sql:ro
    links:
      - tix
    labels:
      com.tarantino.source: '360incentives/delete-me-tix'
```