### PR TITLE
use parsed docker-compose yaml for sources

### DIFF
--- a/dc.sh
+++ b/dc.sh
@@ -98,7 +98,7 @@ generate_compose_file_caches() {
 }
 
 parse_sources() {
-	parse_yaml $(dc_file) |
+	dc config | parse_yaml |
 		grep '^services_.*_labels_com.tarantino.source=' |
 		sed -e 's/^services_\(.*\)_labels_com.tarantino.source=(\(.*\))$/[\1]=\2/'
 }


### PR DESCRIPTION
this will allow us to do stuff in a plugin like:

```sh
dc() {
        TT_PROJECTS=$TT_PROJECTS MY_GIT_BASE=git@github.com/abc docker-compose -f $(dc_file) $@
}
```

and use vars in the docker-compose ie:

```yaml
labels:
      com.tarantino.source: "${MY_GIT_BASE}/my-repo.git"
```