### PR TITLE
Improve yaml parse

### DIFF
--- a/dc.sh
+++ b/dc.sh
@@ -14,6 +14,8 @@ dc() {
 
 dc_get_links() {
 	local key=services_"$1"_links
+	# `docker-compose config` output wreaks havoc with list indentation,
+	# until we find a non-hack way to deal with this, parse file directly
 	parse_yaml $(dc_file) | sed -ne "s|$key+=(\"\(.*\)\")|\1|p"
 }
 

--- a/dc.sh
+++ b/dc.sh
@@ -14,11 +14,7 @@ dc() {
 
 dc_get_links() {
 	local key=services_"$1"_links
-	local links=$key[@]
-	eval $(parse_yaml $(dc_file) | grep $key)
-	for link in ${!links}; do
-		echo $link
-	done
+	parse_yaml $(dc_file) | sed -ne "s|$key+=(\"\(.*\)\")|\1|p"
 }
 
 dc_get_services_with_source() {

--- a/dc.sh
+++ b/dc.sh
@@ -88,6 +88,9 @@ generate_compose_file_caches() {
 		fi
 	fi
 
+	local yaml_cache_file=$(get_workspace_cache_dir)/yaml
+	dc config > "$yaml_cache_file"
+
 	local services_cache_file=$(get_workspace_cache_dir)/services
 	dc config --services > "$services_cache_file"
 
@@ -97,8 +100,17 @@ generate_compose_file_caches() {
 	md5sum "$(dc_file)" > "$md5check"
 }
 
+get_compose_yaml() {
+	if [ "$TT_IS_GLOBAL" = true ]; then
+		generate_compose_file_caches
+		cat "$(get_workspace_cache_dir)/yaml"
+	else
+		dc config
+	fi
+}
+
 parse_sources() {
-	dc config | parse_yaml |
+	get_compose_yaml | parse_yaml |
 		grep '^services_.*_labels_com.tarantino.source=' |
 		sed -e 's/^services_\(.*\)_labels_com.tarantino.source=(\(.*\))$/[\1]=\2/'
 }

--- a/parse-yaml.sh
+++ b/parse-yaml.sh
@@ -6,7 +6,7 @@ parse_yaml() {
 	local w
 	local fs
 	s='[[:space:]]*'
-	w='[a-zA-Z0-9_.]*'
+	w='[a-zA-Z0-9_.-]*'
 	fs="$(echo @|tr @ '\034')"
 	sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
 		-e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" $1 |


### PR DESCRIPTION
This PR does:

  - caches the output of `dc config` (since we will _try_ to use this instead of the raw yaml... see note)
  - update `parse_yaml` to allow for hyphens in the keynames
  - for reading links out of the `parse_yaml` output, now use sed instead of eval (eval died with hyphens in the variable names anyways, among other reasons to change this..)

NOTE:

 `docker-compose config` outputs a slightly modified version of the yaml that screws with the indentation of lists... so yea ideally we'd use that output for links as well, but it was borked.. maybe we can solve this in the future (all the solutions i tried were dirty hacks..)