### PR TITLE
Improve completion

### DIFF
--- a/tt
+++ b/tt
@@ -20,6 +20,10 @@ tt_get_services_with_source() {
 	dc_get_services_with_source
 }
 
+tt_get_available_workspaces() {
+	ws_ls
+}
+
 info() {
 	echo INFO: $*
 }

--- a/tt_completion
+++ b/tt_completion
@@ -8,37 +8,40 @@ tarantino() {
 }
 
 tt_complete() {
-	local word=''
-	local cmd=''
-	local args=0
-	while [[ $# -gt 1 ]]; do
-		case "$1" in
-		-w|--word)
-			word=`echo $2 | tr -d "\""`
-			shift ;;
-		-c|--cmd)
-			cmd=`echo $2 | tr -d "\""`
-			shift ;;
-		-a|--args)
-			args=$2
-			shift ;;
-		esac
-		shift
-	done
+	local word=
+	local cmds=
+	if [ $1 == '-n' ]; then
+		shift;
+		word=
+		cmds=($@)
+	else
+		word=${@: -1}
+		cmds=(${@:1:$#-1})
+	fi
 
-	if [ $args -gt 3 ]; then
-		#multi arg case
-		case "$cmd" in
+	local basecmd=${cmds[0]}
+	local numcmds=${#cmds[@]}
+
+	if [ $numcmds -gt 1 ]; then
+		#multi cmd case
+		case "$basecmd" in
 		create)
 			completion_all_services $word ;;
 		destroy|recreate)
 			completion_running_services $word ;;
 		pull|clone|check)
 			completion_services $word ;;
+		workspace)
+			if [ $numcmds -eq 2 ]; then
+				case "${cmds[1]}" in
+				use|rm)
+					completion_available_workspaces $word ;;
+				esac
+			fi
 		esac
 	else
 		#single arg case
-		case "$cmd" in
+		case "$basecmd" in
 		tt|"")
 			completion_base $word ;;
 		create|browse)
@@ -76,6 +79,10 @@ completion_running_services() {
 
 completion_workspace() {
 	echo "$WORKSPACE_COMMANDS"
+}
+
+completion_available_workspaces() {
+	tarantino get_available_workspaces 2> /dev/null
 }
 
 tt_complete $@

--- a/tt_completion_hook.bash
+++ b/tt_completion_hook.bash
@@ -3,12 +3,12 @@
 _tt_complete() {
 	COMPREPLY=()
 	local cur="${COMP_WORDS[COMP_CWORD]}"
-	local args=${#COMP_WORDS[@]}
-	local cmd=
-	if [ $args -gt 2 ]; then
-		cmd=${COMP_WORDS[1]}
+	local completions=
+	if [ ! -z $cur ]; then
+		completions="$(/usr/local/share/tarantino/tt_completion "${COMP_WORDS[@]:1}")"
+	else
+		completions="$(/usr/local/share/tarantino/tt_completion -n "${COMP_WORDS[@]:1}")"
 	fi
-	local completions="$(/usr/local/share/tarantino/tt_completion --word "\"$cur\"" --cmd "\"$cmd\"" --args "$args")"
 	COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
 }
 


### PR DESCRIPTION
The first commit addresses the PR, improving the completion hook so we can do more, also includes some workspace autocompletion for `workspace use/`workspace rm`

second commit is a tidyup that fixes a nasty nasty bug

the `generate_compose_file_caches` was being called through the `parse_source`, which was triggering another cache-file read before the md5 was updated (recursive call, nasty)

anyways, it seems there was no need to even cache the sources, the yaml cache is enough - `parse_yaml` is super fast (also you could argue the links/sources are never used in anything `ms` sensitive so the cache was unnecessary)