### PR TITLE
forward all 'TT_' variables to the docker-compose command

### DIFF
--- a/dc.sh
+++ b/dc.sh
@@ -8,8 +8,12 @@ dc_file() {
 	echo $(get_workspace_dir)/docker-compose.yml
 }
 
+get_tt_env() {
+	(set -o posix; set) | grep -E 'TT_' | paste -sd " " -
+}
+
 dc() {
-	TT_PROJECTS=$TT_PROJECTS docker-compose -f $(dc_file) $*
+	env $(get_tt_env) docker-compose -f $(dc_file) $*
 }
 
 dc_get_links() {


### PR DESCRIPTION
It feels like the use-case for adding variables to the docker-compose run statements warrants a simpler way of writing a plugin to affect this.

This is a bit of a broad stroke, so im open to alternatives

currently, using a plugin to override the `dc` function entirely is heavy-handed and very error-prone