### PR TITLE
Add CircleCI Tests workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+
+jobs:
+  install:
+    docker:
+      - image: darrenmce/tt-test
+    steps:
+      - checkout
+      - run: sudo -E make install
+
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tarantino - cross-service development environment generation
 
+[![CircleCI](https://circleci.com/gh/meet-tarantino/tarantino.svg?style=svg)](https://circleci.com/gh/meet-tarantino/tarantino)
+
 You've got a shiny new machine and you're fired up to start hacking on your product. Let Tarantino give birth to all of the services comprising your platform.
 
 ## Overview

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,11 @@ tt_install() {
 
 	if [ ! -z "$queue" ]; then
 		echo
-		read -n 1 -p "Install missing dependencies? (Y/n)" CONFIRM
+		# skip the read (effectively saying "yes") if in a CI environment
+		if [ "$CI" != "true" ]; then
+			read -n 1 -p "Install missing dependencies? (Y/n)" CONFIRM
+		fi
+
 		if [ "$CONFIRM" == "n" -o "$CONFIRM" == "N" ]; then
 			echo
 			info "You chose not to install required dependencies, there be dragons."

--- a/test/images/base/Dockerfile
+++ b/test/images/base/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y git make sudo
+
+RUN adduser --disabled-password --gecos '' testuser
+RUN usermod -aG sudo testuser
+RUN echo 'testuser ALL=(ALL) NOPASSWD: ALL' > '/etc/sudoers.d/testuser'
+
+USER testuser
+WORKDIR /home/testuser
+


### PR DESCRIPTION
currently the only job is the "install" job which tests out the install script 

uses the included docker image as a base (i've published it as `darrenmce/tt-test`)