### PR TITLE
Support named networks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
           name: Basic Mongo Tests
           command: test/basic_mongo.bats
       - *cleanup_containers
+      - run:
+          name: tt_ip Tests
+          command: test/tt_ip.bats
+      - *cleanup_containers
 
   noDockerTests:
     docker:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,11 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/test/test_helper/workspace.bash
+++ b/test/test_helper/workspace.bash
@@ -5,7 +5,16 @@ function add_new_workspace() {
 	TMP_DIR=$(mktemp -d)
 	cd ${TMP_DIR}
 	touch docker-compose.yml
-	tt workspace add $1 "${TMP_DIR}"
+	tt workspace add "${WS_NAME}" "${TMP_DIR}"
+	echo "${TMP_DIR}"
+}
+
+function add_ws_from_yaml() {
+	YAML=$1
+	WS_NAME=$(basename $YAML .yml)
+	TMP_DIR=$(mktemp -d)
+	ln -s "${YAML}" "${TMP_DIR}/docker-compose.yml"
+	tt workspace add "${WS_NAME}" "${TMP_DIR}"
 	echo "${TMP_DIR}"
 }
 

--- a/test/test_yamls/networks/default.yml
+++ b/test/test_yamls/networks/default.yml
@@ -1,0 +1,5 @@
+version: '2'
+
+services:
+  hello:
+    image: darrenmce/hello-node

--- a/test/test_yamls/networks/host.yml
+++ b/test/test_yamls/networks/host.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+  hello:
+    image: darrenmce/hello-node
+    network_mode: host

--- a/test/test_yamls/networks/multiple.yml
+++ b/test/test_yamls/networks/multiple.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+  hello:
+    image: darrenmce/hello-node
+    networks:
+      - testnetwork
+      - secondnetwork
+
+networks:
+  testnetwork:
+  secondnetwork:

--- a/test/test_yamls/networks/named.yml
+++ b/test/test_yamls/networks/named.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  hello:
+    image: darrenmce/hello-node
+    networks:
+      - testnetwork
+
+networks:
+  testnetwork:

--- a/test/tt_ip.bats
+++ b/test/tt_ip.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+load 'test_helper/debug'
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/workspace'
+
+DEFAULT_NETWORK_YML="${PWD}/test/test_yamls/networks/default.yml"
+HOST_NETWORK_YML="${PWD}/test/test_yamls/networks/host.yml"
+NAMED_NETWORK_YML="${PWD}/test/test_yamls/networks/named.yml"
+MULTIPLE_NETWORK_YML="${PWD}/test/test_yamls/networks/multiple.yml"
+
+# will match 999.999.999.999 but meh
+IP_ADDRESS_REGEXP='[0-9]{1,3}\.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}'
+
+function setup() {
+	add_ws_from_yaml ${DEFAULT_NETWORK_YML}
+	add_ws_from_yaml ${HOST_NETWORK_YML}
+	add_ws_from_yaml ${NAMED_NETWORK_YML}
+	add_ws_from_yaml ${MULTIPLE_NETWORK_YML}
+}
+
+function teardown() {
+	tt destroy
+	rm_all_workspaces
+}
+
+@test "default network - it should retrieve the IP from the running container" {
+	debug_header
+	run tt workspace use default
+	run tt create
+	run tt ip hello
+	assert_output --regexp "^${IP_ADDRESS_REGEXP}$"
+}
+
+@test "named network - it should retrieve the IP from the running container" {
+	debug_header
+	run tt workspace use named
+	run tt create
+	run tt ip hello
+	assert_output --regexp "^${IP_ADDRESS_REGEXP}$"
+}
+
+@test "host network - it should retrieve 0.0.0.0" {
+	debug_header
+	run tt workspace use host
+	run tt create
+	run tt ip hello
+	assert_output "0.0.0.0"
+}
+
+@test "multiple networks - it should retrieve a list of network IPs from a running container" {
+	debug_header
+	run tt workspace use multiple
+	run tt create
+	run tt ip hello
+	assert_line --regexp "^multiple_testnetwork:${IP_ADDRESS_REGEXP}$"
+	assert_line --regexp "^multiple_secondnetwork:${IP_ADDRESS_REGEXP}$"
+}
+
+@test "multiple networks - quiet mode" {
+	debug_header
+	run tt workspace use multiple
+	run tt create
+	run tt ip hello -q
+	assert_output --regexp "^${IP_ADDRESS_REGEXP}$"
+}
+
+@test "multiple networks - specific network" {
+	debug_header
+	run tt workspace use multiple
+	run tt create
+	run tt ip hello secondnetwork
+	assert_output --regexp "^${IP_ADDRESS_REGEXP}$"
+}
+
+@test "multiple networks - should error when specific network not found" {
+	debug_header
+	run tt workspace use multiple
+	run tt create
+	run tt ip hello unknownnetwork
+	assert_failure
+}

--- a/tt
+++ b/tt
@@ -111,7 +111,7 @@ tt_usage() {
 	echo "  dc - run docker-compose commands in the context of your workspace"
 	echo "  destroy [container...] - destroy all [or named] containers"
 	echo "  install - prepare environment for tarantino"
-	echo "  ip <container> [-q] - retrieve ip addresses for a specific container [-q quiet: for only 1 unlabelled ip]"
+	echo "  ip <container> [-q | network_name] - retrieve ip addresses for a specific container [-q quiet or <network name>]: for only 1 unlabelled ip]"
 	echo "  pull [service] - pull sources for all [or named] projects without changes"
 	echo "  recreate [container...] - recreate all [or named] containers"
 	echo "  restart - restart all containers"
@@ -301,6 +301,18 @@ tt_ip() {
 		fi
 		echo ${tokens[0]} | cut -d ":" -f 2
 		return;
+	fi
+
+	# assume -q not provided
+	if [[ ! -z $2 ]]; then
+		NETWORK_NAME=$(get_workspace)_$2
+		for token in $tokens; do
+			if [[ $(echo ${token} | cut -d ":" -f 1) == $NETWORK_NAME ]]; then
+				echo $token | cut -d ":" -f 2
+				return;
+			fi
+		done
+		return 1;
 	fi
 
 	for pair in $ip_pairs; do

--- a/tt
+++ b/tt
@@ -111,7 +111,7 @@ tt_usage() {
 	echo "  dc - run docker-compose commands in the context of your workspace"
 	echo "  destroy [container...] - destroy all [or named] containers"
 	echo "  install - prepare environment for tarantino"
-	echo "  ip <container> - retrieve ip address of a specific container"
+	echo "  ip <container> [-q] - retrieve ip addresses for a specific container [-q quiet: for only 1 unlabelled ip]"
 	echo "  pull [service] - pull sources for all [or named] projects without changes"
 	echo "  recreate [container...] - recreate all [or named] containers"
 	echo "  restart - restart all containers"
@@ -152,14 +152,14 @@ tt_browse() {
 	  return 1
 	fi
 
-	local ip=$(tt_ip $container)
+	local ip=$(tt_ip $container -q)
 	local url=http://$ip$port$path
 
 	if [ "$ip" = "" ]; then
 		echo $container is not running, starting
 		tt_create $container
 
-		local ip=$(tt_ip $container)
+		local ip=$(tt_ip $container -q)
 		local host=http://$ip$port
 		local url=$host$path
 
@@ -272,7 +272,8 @@ tt_create() {
 	fi
 	dc up -d $@
 	for service in $@; do
-		echo $service: $(tt_ip $service)
+		echo "$service ip(s):"
+		tt_ip $service
 	done
 }
 
@@ -286,8 +287,26 @@ tt_destroy() {
 	fi
 }
 
+
 tt_ip() {
-	docker inspect --format '{{ .NetworkSettings.Networks.'$(get_workspace)'_default.IPAddress }}' $(get_workspace)_$1\_1
+	ip_pairs=$(docker inspect --format '{{range $i, $n := .NetworkSettings.Networks }}{{$i}}:{{$n.IPAddress}} {{end}}' $(get_workspace)_$1\_1)
+	tokens=($(echo $ip_pairs | tr ' ' "\n"))
+
+	# if in quiet mode, or there is only one network, output only the one IP
+	if [[ $2 == "-q" ]] || [[ ${#tokens[@]} -eq 1 ]]; then
+		# if the container is in host mode, output 0.0.0.0
+		if [[ ${tokens[0]} == "host:" ]]; then
+			echo "0.0.0.0"
+			return;
+		fi
+		echo ${tokens[0]} | cut -d ":" -f 2
+		return;
+	fi
+
+	for pair in $ip_pairs; do
+		echo $pair
+	done
+
 }
 
 tt_recreate() {


### PR DESCRIPTION
adds some new behaviour for the `tt ip` command

when theres only one IP associated with a container, there should be no difference (except that a named network will actually return the IP now)

when theres multiple networks, it will return a named list:

```sh
$ tt ip both
test_othernetwork:172.21.0.3
test_somenetwork:172.18.0.3
```

unless you pass the `-q` flag, in which it will just return the first one (order not guarentueed)

the `-q` flag maintains `tt browse` functionality