### PR TITLE
adds tt_version and version breadcrumb to install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,22 @@
+INSTALL_DIR = /usr/local/share/tarantino
+BIN_DIR = /usr/local/bin
+COMPLETION_DIR = /etc/bash_completion.d
+
 all:
 
 install: uninstall
-	cp tt /usr/local/bin/ && \
-		mkdir -p /usr/local/share/tarantino/templates && \
-		cp *.sh /usr/local/share/tarantino && \
-		cp -R templates /usr/local/share/tarantino && \
-		cp -f tt_completion /usr/local/share/tarantino && \
-		cp -f tt_completion_hook.bash /etc/bash_completion.d/ && \
+	mkdir -p ${INSTALL_DIR}/templates && \
+		cp *.sh ${INSTALL_DIR} && \
+		cp -f tt ${INSTALL_DIR} && \
+		ln -sf ${INSTALL_DIR}/tt ${BIN_DIR}/tt &&\
+		cp -f tt_completion ${INSTALL_DIR} && \
+		cp -R templates ${INSTALL_DIR} && \
+		cp -f tt_completion_hook.bash ${COMPLETION_DIR}/ && \
+		git describe --always --tags > ${INSTALL_DIR}/version.txt &&\
 		./tt install && \
-		echo Installation complete. && \
-		echo Press enter to continue.
+		echo Installation complete.
 
 uninstall:
-		rm -f /usr/local/bin/tt && \
-		rm -rf /usr/local/share/tarantino && \
-		rm -f /etc/bash_completion.d/tt_completion_hook.bash
-
+		rm -f ${BIN_DIR}/tt && \
+		rm -rf ${INSTALL_DIR} && \
+		rm -f ${COMPLETION_DIR}/tt_completion_hook.bash

--- a/test/valid_install.bats
+++ b/test/valid_install.bats
@@ -21,3 +21,12 @@ load 'test_helper/bats-assert/load'
 	run grep -w "${USER}" <<< $GROUP_MEMBERS
 	assert_equal "$output" "${USER}"
 }
+
+@test "tt is available" {
+	hash tt
+}
+
+@test "tt version is available" {
+	tt version
+	assert_success
+}

--- a/tt
+++ b/tt
@@ -44,6 +44,7 @@ main() {
 		case "$1" in
 		install) ;;
 		upgrade) ;;
+		version) ;;
 		workspace) ;;
 		*)
 			>&2 echo "ERROR: You don't have an active workspace. Run 'tt workspace use <workspace>' to select one."
@@ -116,6 +117,7 @@ tt_usage() {
 	echo "  recreate [container...] - recreate all [or named] containers"
 	echo "  restart - restart all containers"
 	echo "  upgrade - upgrade to latest tarantino version"
+	echo "  version - outputs the tt version"
 	echo "  workspace [command] - create, remove and switch workspaces"
 	workspace_plugin_usage_
 }
@@ -341,6 +343,14 @@ tt_upgrade() {
 
 tt_get_workspace() {
 	get_workspace
+}
+
+tt_version() {
+	if ! $TT_IS_GLOBAL; then
+		echo "local"
+		return 0;
+	fi
+	cat "${TT_SHARE}/version.txt" 2> /dev/null
 }
 
 main $@

--- a/tt_completion
+++ b/tt_completion
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BASE_COMMANDS="browse check clone create dc destroy install ip pull recreate restart upgrade usage workspace"
+BASE_COMMANDS="browse check clone create dc destroy install ip pull recreate restart upgrade usage version workspace"
 WORKSPACE_COMMANDS="init add edit rm ls use current upgrade"
 
 tarantino() {


### PR DESCRIPTION
  - refactored install script to use variables and a symlink

resolves #43 

usage: `tt version`

todo:

  - [ ] tag master with `v1.0`